### PR TITLE
Remove itunes.py dependency

### DIFF
--- a/README
+++ b/README
@@ -9,9 +9,8 @@ Instructions
 ========================
 
 1. git clone git://github.com/almonteb/DroidSync.git
-2. Get iTunes.py from http://www.math.columbia.edu/%7Ebayer/Python/iTunes/
-3. Install appscript via easy_install (sudo easy_install appscript)
-4. Enjoy
+2. Install appscript via easy_install (sudo easy_install appscript)
+3. Enjoy
 
 ========================
 Usage
@@ -24,5 +23,8 @@ Contributors
 ========================
 
 Brendan Almonte (almonteb@datawh.net) - Current maintainer
+
+Dave Bayer (https://www.math.columbia.edu/~bayer/Python/iTunes/), he has written
+the iTunes integration Code.
 
 Feel free to fork, make changes and send a pull request.

--- a/sync.py
+++ b/sync.py
@@ -155,13 +155,13 @@ if len(sys.argv) is not 3:
     sys.exit()
 
 outdir  = sys.argv[2]
-pl_name = sys.argv[1]
+pl_name = sys.argv[1].decode("utf-8")
 
 if not os.path.exists(outdir):
     print "directory: " + outdir + " doesn't exist...\n"
     sys.exit()
 
-print_header("Playlist: " + pl_name)
+print_header(u"Playlist: {}".format(pl_name))
 sync_playlist(pl_name, outdir)
 print_header("Sync of playlist " + pl_name + " complete!")
 

--- a/sync.py
+++ b/sync.py
@@ -29,12 +29,16 @@
 #
 ###############################################################################
 
-import os, sys, codecs, glob
-import xml.etree.ElementTree as ET
+#from __future__ import unicode_literals
+import os
+import sys
+import glob
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'iTunes'))
+
 import shutil
 
-from appscript import *
-from iTunes import *
+from appscript import app
 
 ###############################################################################
 # Misc Functions
@@ -107,13 +111,14 @@ def clean_dir(tracks, directory):
         if not os.listdir(artist):
             os.rmdir(artist)
 
+
 def sync_playlist(playlist, directory):
-    pl      = get_playlists()
+    pl      = app('iTunes').user_playlists()
     files   = get_files(directory)
     
     for p in pl:
         if p.name() == playlist:
-            tracks = get_tracks(p)
+            tracks = p.file_tracks()
 
             # Copy...
             print_header("Copying tracks")

--- a/sync.py
+++ b/sync.py
@@ -113,6 +113,8 @@ def clean_dir(tracks, directory):
 
 
 def sync_playlist(playlist, directory):
+    # iTunes integration taken from
+    # http://www.math.columbia.edu/%7Ebayer/Python/iTunes/
     pl      = app('iTunes').user_playlists()
     files   = get_files(directory)
     


### PR DESCRIPTION
I removed the dependency to the iTunes.py script. he DroidSync project uses only two calls to the iTunes.app via appscript. I replaced the iTunes.py functions by the direct appscript code.

This patch contains the changes from the PR #1, so merge PR #1 at first.
